### PR TITLE
Fix item tooltips.

### DIFF
--- a/C4Extras/C4Discs/assets/minecraft/lang/en_us.json
+++ b/C4Extras/C4Discs/assets/minecraft/lang/en_us.json
@@ -1,7 +1,12 @@
 {
   "item.minecraft.music_disc_11.desc": "C418 - eleven",
+  "jukebox_song.minecraft.11": "C418 - eleven",
   "item.minecraft.music_disc_5.desc": "C418 - one",
+  "jukebox_song.minecraft.5": "C418 - one",
   "item.minecraft.music_disc_otherside.desc": "C418 - dog",
-  "item.minecraft.music_disc_pigstep.desc": "C418 - jayson glove",
-  "item.minecraft.music_disc_relic.desc": "C418 - depado"
+  "jukebox_song.minecraft.otherside": "C418 - dog",
+  "item.minecraft.music_disc_pigstep.desc": "C418 - vlem",
+  "jukebox_song.minecraft.pigstep": "C418 - vlem",
+  "item.minecraft.music_disc_relic.desc": "C418 - depado",
+  "jukebox_song.minecraft.relic": "C418 - depado"
 }

--- a/C4Extras/C4Discs/assets/minecraft/lang/en_us.json
+++ b/C4Extras/C4Discs/assets/minecraft/lang/en_us.json
@@ -5,8 +5,8 @@
   "jukebox_song.minecraft.5": "C418 - one",
   "item.minecraft.music_disc_otherside.desc": "C418 - dog",
   "jukebox_song.minecraft.otherside": "C418 - dog",
-  "item.minecraft.music_disc_pigstep.desc": "C418 - vlem",
-  "jukebox_song.minecraft.pigstep": "C418 - vlem",
+  "item.minecraft.music_disc_pigstep.desc": "C418 - jayson glove",
+  "jukebox_song.minecraft.pigstep": "C418 - jayson glove",
   "item.minecraft.music_disc_relic.desc": "C418 - depado",
   "jukebox_song.minecraft.relic": "C418 - depado"
 }

--- a/C4Extras/C4Nether/assets/minecraft/lang/en_us.json
+++ b/C4Extras/C4Nether/assets/minecraft/lang/en_us.json
@@ -1,3 +1,4 @@
 {
- "item.minecraft.music_disc_pigstep.desc": "C418 - vlem"
+  "item.minecraft.music_disc_pigstep.desc": "C418 - vlem",
+  "jukebox_song.minecraft.pigstep": "C418 - vlem"
 }


### PR DESCRIPTION
Noticed when hovering over a disc that the old song name would show up. This fixes it.

Also, please specify on the C4Discs Modrinth page which zip is for what version. There's one that says 1.20.5+, but I have no idea of what version the other one is for.

Thank you very much for this resource pack.